### PR TITLE
fix xml output segmentation fault

### DIFF
--- a/src/outxml.c
+++ b/src/outxml.c
@@ -65,7 +65,7 @@ void xml_stylehead(FILE *outf, Outchoices *od)
 	*outfp=outf;
 
 	// KLUDGE!!!!
-	opts=(Options*)((int)od-offsetof(Options,outopts));	
+	opts=(Options*)((char*)od-offsetof(Options,outopts));
 
 	t=time(0); 
 	strftime( buffer, 256, "%Y%m%d%H%M%S", gmtime(&t) );


### PR DESCRIPTION
Hello, 
This patch fix xml output segmentation fault bug.

offsetof used `int` type before, but it makes failed about memory address calculation so cannot hold correct `Options` struct variable.

After change to `char*` type, segmentation fault not occure.
