### PR TITLE
fixed: -DHAVE_PCRE is ignored

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -10,7 +10,7 @@ CFLAGS = -O2    # options, e.g. for optimisation or ANSI compilation.
 #                 HP/UX cc needs CFLAGS = -Aa (HP/UX 9) or -Ae (HP/UX 10)
 #                 BeOS needs CFLAGS = -O2 -Wl,-L/boot/home/config/lib
 #                 BS2000/OSD needs CFLAGS = -XLLML -XLLMK
-#                 NeXTSTEP needs CFLAGS = -O2 -pipe -no-precomp 
+#                 NeXTSTEP needs CFLAGS = -O2 -pipe -no-precomp
 DEFS =          # any combination of -DNOPIPES -DNODNS -DNODIRENT -DNOGLOB ...
 #                 ... -DNOOPEN -DNOFOLLOW -DNOALARM -DNOGRAPHICS -DNOGMTIME ...
 #                 ... -DEBCDIC -DUSE_PLAIN_SETJMP ...
@@ -54,32 +54,12 @@ OBJS = alias.o analog.o cache.o dates.o globals.o hash.o init.o init2.o \
 	input.o macinput.o macstuff.o output.o output2.o outcro.o outhtml.o \
 	outlatex.o outplain.o outxhtml.o outxml.o process.o settings.o sort.o \
 	tree.o utils.o win32.o
-SUBDIRS = bzip2 libgd libpng pcre2 unzip zlib
+SUBDIRS = bzip2 libgd libpng unzip zlib
 SUBDIROBJS = libgd/gd.o  libgd/gd_io.o libgd/gd_io_file.o libgd/gd_png.o \
 	libgd/gdfontf.o libgd/gdfonts.o libgd/gdtables.o \
 	libpng/png.o libpng/pngerror.o libpng/pngmem.o libpng/pngset.o \
 	libpng/pngtrans.o libpng/pngwio.o libpng/pngwrite.o \
 	libpng/pngwtran.o libpng/pngwutil.o \
-	pcre2/src/libpcre2_8_la-pcre2_auto_possess.o \
-	pcre2/src/libpcre2_8_la-pcre2_chartables.o \
-	pcre2/src/libpcre2_8_la-pcre2_chkdint.o \
-	pcre2/src/libpcre2_8_la-pcre2_compile.o \
-	pcre2/src/libpcre2_8_la-pcre2_context.o \
-	pcre2/src/libpcre2_8_la-pcre2_convert.o \
-	pcre2/src/libpcre2_8_la-pcre2_extuni.o \
-	pcre2/src/libpcre2_8_la-pcre2_find_bracket.o \
-	pcre2/src/libpcre2_8_la-pcre2_match.o \
-	pcre2/src/libpcre2_8_la-pcre2_match_data.o \
-	pcre2/src/libpcre2_8_la-pcre2_newline.o \
-	pcre2/src/libpcre2_8_la-pcre2_ord2utf.o \
-	pcre2/src/libpcre2_8_la-pcre2_pattern_info.o \
-	pcre2/src/libpcre2_8_la-pcre2_script_run.o \
-	pcre2/src/libpcre2_8_la-pcre2_string_utils.o \
-	pcre2/src/libpcre2_8_la-pcre2_study.o \
-	pcre2/src/libpcre2_8_la-pcre2_tables.o \
-	pcre2/src/libpcre2_8_la-pcre2_ucd.o \
-	pcre2/src/libpcre2_8_la-pcre2_valid_utf.o \
-	pcre2/src/libpcre2_8_la-pcre2_xclass.o \
 	zlib/adler32.o zlib/compress.o zlib/crc32.o zlib/deflate.o \
 	zlib/gzio.o zlib/infblock.o zlib/infcodes.o zlib/inffast.o \
 	zlib/inflate.o zlib/inftrees.o zlib/infutil.o zlib/trees.o \
@@ -87,8 +67,35 @@ SUBDIROBJS = libgd/gd.o  libgd/gd_io.o libgd/gd_io_file.o libgd/gd_png.o \
 	bzip2/bzlib.o bzip2/blocksort.o bzip2/compress.o bzip2/crctable.o \
 	bzip2/decompress.o bzip2/huffman.o bzip2/randtable.o
 HEADERS = anlghead.h anlghea2.h anlghea3.h anlghea4.h macdir.h \
-	pcre2/src/pcre2.h.generic libgd/gd.h libgd/gdfontf.h libgd/gdfonts.h unzip/unzip.h \
+	libgd/gd.h libgd/gdfontf.h libgd/gdfonts.h unzip/unzip.h \
 	zlib/zlib.h bzip2/bzlib.h
+	ifneq (,$(findstring -DHAVE_PCRE,$(DEFS))) # Found -DHAVE_PCRE FLAG. Using library installed in the operating system.
+		LIBS += -lpcre2-8
+	else
+		HEADERS += pcre2/src/pcre2.h.generic
+		SUBDIRS += pcre2
+		SUBDIROBJS += 	pcre2/src/libpcre2_8_la-pcre2_auto_possess.o \
+			pcre2/src/libpcre2_8_la-pcre2_chartables.o \
+			pcre2/src/libpcre2_8_la-pcre2_chkdint.o \
+			pcre2/src/libpcre2_8_la-pcre2_compile.o \
+			pcre2/src/libpcre2_8_la-pcre2_context.o \
+			pcre2/src/libpcre2_8_la-pcre2_convert.o \
+			pcre2/src/libpcre2_8_la-pcre2_extuni.o \
+			pcre2/src/libpcre2_8_la-pcre2_find_bracket.o \
+			pcre2/src/libpcre2_8_la-pcre2_match.o \
+			pcre2/src/libpcre2_8_la-pcre2_match_data.o \
+			pcre2/src/libpcre2_8_la-pcre2_newline.o \
+			pcre2/src/libpcre2_8_la-pcre2_ord2utf.o \
+			pcre2/src/libpcre2_8_la-pcre2_pattern_info.o \
+			pcre2/src/libpcre2_8_la-pcre2_script_run.o \
+			pcre2/src/libpcre2_8_la-pcre2_string_utils.o \
+			pcre2/src/libpcre2_8_la-pcre2_study.o \
+			pcre2/src/libpcre2_8_la-pcre2_tables.o \
+			pcre2/src/libpcre2_8_la-pcre2_ucd.o \
+			pcre2/src/libpcre2_8_la-pcre2_valid_utf.o \
+			pcre2/src/libpcre2_8_la-pcre2_xclass.o
+	endif
+
 ALLCFLAGS = $(CFLAGS) $(DEFS) -D$(OS)
 ALLOBJS = $(OBJS) $(SUBDIROBJS)
 
@@ -106,11 +113,13 @@ libgd: ALWAYS
 libpng: ALWAYS
 	cd libpng && $(MAKE) 'CC=$(CC)' 'ALLCFLAGS=$(ALLCFLAGS)'
 
+ifeq (,$(findstring -DHAVE_PCRE,$(DEFS))) # Avoid compiling pcre2 unnecessarily
 pcre2: ALWAYS
 	chmod 755 pcre2/132html pcre2/ar-lib pcre2/CheckMan pcre2/CleanTxt pcre2/compile pcre2/config.guess pcre2/config.sub pcre2/configure pcre2/depcomp pcre2/Detrail pcre2/install-sh pcre2/missing pcre2/perltest.sh pcre2/PrepareRelease pcre2/RunGrepTest pcre2/RunTest pcre2/test-driver
 	chmod 755 pcre2/cmake pcre2/doc pcre2/m4 pcre2/src pcre2/testdata pcre2/vms
 	chmod 755 pcre2/src/sljit pcre2/src/sljit/allocator_src/
 	cd pcre2 && ./configure && $(MAKE) 'CC=$(CC)' 'ALLCFLAGS=$(ALLCFLAGS)'
+endif
 
 unzip: ALWAYS
 	cd unzip && $(MAKE) 'CC=$(CC)' 'ALLCFLAGS=$(ALLCFLAGS)'


### PR DESCRIPTION
Fix: -DHAVE_PCRE is ignored (https://github.com/c-amie/analog-ce/issues/6)

You can compile with `make DEFS='-DHAVE_PCRE'` directly on command line.

To check the dynamic linked libraries, you can use `ldd`.

`make DEFS='-DHAVE_PCRE'`
<img width="881" height="129" alt="image" src="https://github.com/user-attachments/assets/1f808f9e-37db-42fa-9d73-2af35fc658a7" />

Only `make`. 
<img width="881" height="129" alt="image" src="https://github.com/user-attachments/assets/7f46b71b-03e8-4341-be33-f8ce583208bd" />

Thanks!